### PR TITLE
remove temp dirs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 psutil~=5.9
+uvicorn

--- a/src/flaskwebgui.py
+++ b/src/flaskwebgui.py
@@ -1,8 +1,8 @@
 import os
+import shutil
 import time
 import uuid
 import signal
-import psutil
 import tempfile
 import platform
 import subprocess
@@ -14,11 +14,21 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Union
 from contextlib import suppress
 
+import psutil
+
 FLASKWEBGUI_USED_PORT = None
 FLASKWEBGUI_BROWSER_PROCESS = None
-
 OPERATING_SYSTEM = platform.system().lower()
 PY = "python3" if OPERATING_SYSTEM in ["linux", "darwin"] else "python"
+
+TEMP_DIRS_CREATED = []
+
+
+def cleanup_temp_dirs():
+    for dir_path in TEMP_DIRS_CREATED:
+        if os.path.exists(dir_path):
+            print(f'Removing Temp dir {dir_path}')
+            shutil.rmtree(dir_path, ignore_errors=True)
 
 
 def get_free_port():
@@ -218,6 +228,7 @@ class FlaskUI:
         self.profile_dir = os.path.join(
             tempfile.gettempdir(), self.profile_dir_prefix + uuid.uuid4().hex
         )
+        TEMP_DIRS_CREATED.append(self.profile_dir)
         base_url = f"http://127.0.0.1:{self.port}"
         self.url = f"{base_url}/{self.url_suffix}" if self.url_suffix else base_url
 
@@ -260,11 +271,15 @@ class FlaskUI:
         if isinstance(server_process, Process):
             if self.on_shutdown is not None:
                 self.on_shutdown()
+            cleanup_temp_dirs()
             server_process.kill()
+
         else:
             if self.on_shutdown is not None:
                 self.on_shutdown()
+            cleanup_temp_dirs()
             kill_port(self.port)
+
 
     def run(self):
         if self.on_startup is not None:


### PR DESCRIPTION
fwg creates a new profile dir on every run. a week of testing a project created ~300k files using ~30GB...

this update adds a TEMP_DIRS_CREATED global var, and a function clean_temp_dirs which is called just before kill_port() on shutdown